### PR TITLE
#162163164 Users should receive a JWT on successful Registration

### DIFF
--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -1,10 +1,60 @@
-# import jwt
-#
-# from django.conf import settings
-#
-# from rest_framework import authentication, exceptions
-#
-# from .models import User
+import jwt
 
-"""Configure JWT Here"""
+from django.conf import settings
 
+from rest_framework import authentication, exceptions
+from rest_framework.authentication import (
+    BaseAuthentication, get_authorization_header)
+from .models import User
+
+
+class JWTAuthentication(authentication.BaseAuthentication):
+
+    authentication_header_prefix = 'Bearer'
+
+    def authenticate(self, request):
+        """
+        The method splits the token header and
+        if successful it returns user/token combination 
+        to the _authenticate_credentials method. if not, 
+        throws an error.
+        """
+        request.user = None
+
+        auth_header = authentication.get_authorization_header(request).split()
+        auth_header_prefix = self.authentication_header_prefix.lower()
+
+        if not auth_header or len(auth_header) == 1 or len(auth_header) > 2:
+            return None
+
+        bearer = auth_header[0].decode('utf-8')
+        token = auth_header[1].decode('utf-8')
+
+        if bearer.lower() != auth_header_prefix:
+            return None
+
+        return self._authenticate_credentials(request, token)
+
+    def _authenticate_credentials(self, request, token):
+        """
+        Authenticates the given credentials received from the authenticate method 
+        and if authentication is successful, returns the user and token. 
+        if not, throws an error.
+        """
+        try:
+            payload = jwt.decode(token, settings.SECRET_KEY)
+        except:
+            msg = 'Invalid authentication. Could not decode token.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            user = User.objects.get(pk=payload['id'])
+        except User.DoesNotExist:
+            msg = 'User with this token was not found.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        if not user.is_active:
+            msg = 'User with this token has been deactivated.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        return (user, token)

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -117,4 +117,18 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         return self.username
 
+    @property
+    def token(self):
+        """
+        Generate a JSON Web Token on Registration and Login with an expiry
+        date set to 14 days.
+        """
+        dt = datetime.now() + timedelta(days=14)
+
+        token = jwt.encode({
+            'id': self.pk,
+            'exp': int(dt.strftime('%s'))
+        }, settings.SECRET_KEY, algorithm='HS256')
+
+        return token.decode('utf-8')
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -23,7 +23,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = User
         # List all of the fields that could possibly be included in a request
         # or response, including fields specified explicitly above.
-        fields = ['email', 'username', 'password']
+        fields = ['email', 'username', 'password', 'token']
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
@@ -34,7 +34,7 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.CharField(max_length=255)
     username = serializers.CharField(max_length=255, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
-
+    token = serializers.CharField(max_length=255, read_only=True)
 
     def validate(self, data):
         # The `validate` method is where we make sure that the current
@@ -87,7 +87,7 @@ class LoginSerializer(serializers.Serializer):
         return {
             'email': user.email,
             'username': user.username,
-
+            'token': user.token,
         }
 
 
@@ -106,7 +106,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('email', 'username', 'password')
+        fields = ('email', 'username', 'password', 'token')
 
         # The `read_only_fields` option is an alternative for explicitly
         # specifying the field with `read_only=True` like we did for password
@@ -115,6 +115,7 @@ class UserSerializer(serializers.ModelSerializer):
         # password field, we needed to specify the `min_length` and 
         # `max_length` properties too, but that isn't the case for the token
         # field.
+        read_only_fields = ('token',)
 
 
     def update(self, instance, validated_data):

--- a/authors/apps/authentication/tests/test_auth.py
+++ b/authors/apps/authentication/tests/test_auth.py
@@ -1,0 +1,95 @@
+from rest_framework import serializers, status
+from rest_framework.test import APITestCase
+from ..backends import JWTAuthentication
+from ..models import User
+
+class AuthTestCase(APITestCase):
+    '''Test JWT authentication for ah-backend-zues'''   
+
+    def test_token_received_after_successful_registration(self):
+        """
+        Test that a user will receive 
+        a token after successfull registration
+        """
+        data = {
+            "user": {
+                "username": "eric",
+                "email": "eric@gmail.com",
+                "password": "incorrect"
+            }
+        }                    
+        response = self.client.post('/api/users/' ,data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert 'token' in response.data
+
+    def test_token_received_after_successful_login(self):
+        """
+        Test that a user will receive 
+        a token after successfull login
+        """
+        data = {
+            "user": {
+                "username": "eric",
+                "email": "eric@gmail.com",
+                "password": "incorrect"
+            }
+        }
+        response = self.client.post('/api/users/',data, format='json')
+        data = {"user": { "email": "eric@gmail.com", "password":"incorrect"}}
+        response = self.client.post('/api/users/login/',data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK) 
+        assert 'token' in response.data
+
+    def test_user_can_get_current_user(self):
+        """
+        Test that a user will receive 
+        a token after successfull login
+        """
+        data = {
+            "user": {
+                "username": "eric",
+                "email": "eric@gmail.com",
+                "password": "incorrect"
+            }
+        }
+        response = self.client.post('/api/users/',data, format='json')
+        data = {
+            "user": {
+                "email": "eric@gmail.com",
+                "password": "incorrect"
+            }
+        }
+        response = self.client.post('/api/users/login/',data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK) 
+        assert 'token' in response.data
+        self.client.credentials(HTTP_AUTHORIZATION= 'Bearer ' + response.data['token'])
+        response = self.client.get('/api/user/', format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)   
+
+    def test_wrong_token_header_prefix(self):
+        """
+        Test when wrong authoriation header
+        prefix is entered
+        """
+        self.client.credentials(HTTP_AUTHORIZATION= 'hgfds ' + 'poiuytfd')
+        response = self.client.get("/api/user/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_for_invalid_token(self):
+        """
+        Test when an invalid 
+        authorisation header is provided
+        """
+        self.client.credentials(HTTP_AUTHORIZATION= 'Token ' + 'yyuug')
+        response = self.client.get("/api/user/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  
+
+    def test_no_token_in_header(self):
+        """
+        Test when no authorization token
+        is entered in the header
+        """
+        self.client.credentials(HTTP_AUTHORIZATION= ' ' + 'shfdj')
+        response = self.client.get("/api/user/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN) 

--- a/authors/apps/authentication/tests/tests.py
+++ b/authors/apps/authentication/tests/tests.py
@@ -1,7 +1,7 @@
 from django.urls import reverse, path
 from rest_framework.test import APITestCase
 from rest_framework import status
-from .models import User
+from ..models import User
 
 class Authentication(APITestCase):
      

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -146,9 +146,9 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'authors.apps.core.exceptions.core_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error',
 
-    # 'DEFAULT_AUTHENTICATION_CLASSES': (
-    #     'authors.apps.authentication.backends.JWTAuthentication',
-    # ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'authors.apps.authentication.backends.JWTAuthentication',
+    ),
 }
 
 # Configure Django App for Heroku.


### PR DESCRIPTION
**What does this PR do?**
Generates a JSON Web Token after a user has provided the correct credentials during registration or login. 
**Description of Task to be completed?**
* Adds user token generation functionality
* Adds Authorization functionality
* Adds a tests module
* Adds tests for authentication

**How should this be manually tested?**
* Open POSTMAN, add the link /api/users/ to the localhost url to register a new user.
* Provide the body format for registration from the documentation { "user":{ "username": "Jacob", "email": "jake@jake.jake", "password": "jakejake" } } 
User should be able to receive a JSON Web Token after both registration and login.

**What are the relevant pivotal tracker stories?** 
#16216316

Screenshots (if appropriate)
<img width="972" alt="screen shot 2018-12-03 at 3 17 32 pm" src="https://user-images.githubusercontent.com/9946845/49456577-6862f300-f7fa-11e8-84f7-c7de2390d9f5.png">
