### PR TITLE
#162163177 Add functionality to list all users and their profiles

### DIFF
--- a/authors/apps/authentication/tests/test_list_users_functionality.py
+++ b/authors/apps/authentication/tests/test_list_users_functionality.py
@@ -1,0 +1,46 @@
+from rest_framework.test import APITestCase, APIRequestFactory
+from rest_framework import status
+import json
+from rest_framework.reverse import reverse
+from ..models import User
+from ..views import RegistrationAPIView, AccountVerified
+
+
+class ListUserFunctionalityTests(APITestCase):
+    def setUp(self):
+        self.user_data = {'user': {
+            'username': 'Jack Sparrow',
+            'email': 'sparrow@gmail.com',
+            'password': 'SeaC4ptain' 
+        }}
+        self.url = reverse("registration")
+        self.client.post(self.url, self.user_data, format='json')
+        self.request = APIRequestFactory().post(
+            reverse("registration")
+        )
+        user = User.objects.get()
+        request = self.request
+        token, uid = RegistrationAPIView.generate_token(user, request)
+        response = self.account_verification(token, uid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user =User.objects.get()
+        self.assertTrue(user.is_verified)
+    
+    def account_verification(self, token, uid):
+        request = APIRequestFactory().get(
+            reverse("verify_account", kwargs={"token": token, "uid":uid})
+        )
+        verify = AccountVerified.as_view()
+        response = verify(request, token=token, uid=uid)
+        return response
+
+    def test_api_can_list_all_registered_users(self):
+        resp = self.client.post('/api/users/login/', data=self.user_data, format='json')
+        body = json.loads(resp.content)
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + body['user']['token'])
+        resp = self.client.get('/api/authors/')
+        body = json.loads(resp.content)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(body['authors'][0]['username'], 'Jack Sparrow')
+        self.assertEqual(body['authors'][0]['email'], 'sparrow@gmail.com')
+

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -3,7 +3,7 @@ from rest_framework_swagger.views import get_swagger_view
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView, AccountVerified, 
-    PasswordResetAPIView, PasswordUpdateAPIView
+    PasswordResetAPIView, PasswordUpdateAPIView, UsersRetrieveAPIView
 )
 
 schema_view = get_swagger_view(title='Authors Haven')
@@ -15,6 +15,6 @@ urlpatterns = [
     path('swagger/', schema_view),
     path('users/verified_account/<token>/<uid>', AccountVerified.as_view(), name="verify_account"),
     path('users/password_reset/', PasswordResetAPIView.as_view()),
-    path('users/password_update/<token>',PasswordUpdateAPIView.as_view()),
-    
+    path('users/password_update/<token>', PasswordUpdateAPIView.as_view()),
+    path('authors/', UsersRetrieveAPIView.as_view())
 ]

--- a/authors/apps/profiles/test_profile.py
+++ b/authors/apps/profiles/test_profile.py
@@ -24,6 +24,6 @@ class TestUserProfile(APITestCase):
         for u in usr:
             self.reg_user = u['user']
 
-        response = self.client.put('/api/users/profiles/{}'.format(self.reg_user), update_data, format ='json')
+        response = self.client.put('/api/users/profiles/{}'.format(self.reg_user) + '/', update_data, format ='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -4,5 +4,5 @@ from .views import UserProfiles,Updateprofile
 
 urlpatterns = [
     path('users/profiles', UserProfiles.as_view()),
-    path('users/profiles/<int:user_id>', Updateprofile.as_view())
+    path('users/profiles/<int:user_id>/', Updateprofile.as_view(), name='profile')
 ]


### PR DESCRIPTION
## What does this PR do?
It adds a feature that enables a logged in user to see a list and profiles of all registered authors
### Description of task to be completed?
* Add API endpoint to return a list of all authors and their profiles
* Add authentication to the endpoint (only logged in users allowed)
* Write tests for the added endpoint
### How should this be manually tested?
* Clone this repository and checkout the branch: 'ft-list-users-and-profiles-162163177'
* Setup project database (make and apply migrations)
* Register some users using Postman
* Retrieve all users with Postman by hitting the endpoint: GET /api/authors/
* Verify that the users have been returned
### What are the relevant pivotal tracker stories?
[#162163177](https://www.pivotaltracker.com/n/projects/2227671/stories/162163177)