### PR TITLE
#162163171 Add feature to enable logged in users to rate articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from authors.apps.profiles.models import UserProfile
 from authors.apps.core.models import TimestampedModel
 
 
@@ -6,7 +7,6 @@ class Article(TimestampedModel):
     """
     Create and return an `Article` with a title, description and body.
     """
-
     slug = models.SlugField(
         db_index=True,
         max_length=255,
@@ -19,6 +19,16 @@ class Article(TimestampedModel):
         'profiles.UserProfile',
         on_delete=models.CASCADE,
         related_name='articles')
+    score = models.FloatField(default=0)
 
     def __str__(self):
         return self.title
+
+
+class Rating(models.Model):
+    """
+    Model to store ratings for user created articles.
+    """
+    user = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
+    article_id = models.ForeignKey(Article, on_delete=models.CASCADE)
+    score = models.IntegerField()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,42 +1,38 @@
 from rest_framework import serializers
-
 from authors.apps.profiles.serializers import GetUserProfileSerializer
-
-from .models import Article
+from .models import Article, Rating
 
 
 class ArticleSerializer(serializers.ModelSerializer):
     """
     Serializes article requests and creates a new article.
     """
-
     author = GetUserProfileSerializer(read_only=True)
     description = serializers.CharField(required=False)
     slug = serializers.SlugField(required=False)
     createdAt = serializers.SerializerMethodField(method_name='get_created_at')
     updatedAt = serializers.SerializerMethodField(method_name='get_updated_at')
+    score = serializers.FloatField(required=False)
 
     class Meta:
         model = Article
         fields = (
-            'author',
-            'body',
-            'createdAt',
-            'description',
-            'slug',
-            'title',
-            'updatedAt',
+            'author', 'body', 'createdAt', 'description',
+            'slug', 'title', 'updatedAt', 'score'
         )
 
     def create(self, validated_data):
-
         author = self.context.get('author', None)
         return Article.objects.create(author=author, **validated_data)
 
     def get_created_at(self, instance):
-
         return instance.created_at.isoformat()
 
     def get_updated_at(self, instance):
-
         return instance.updated_at.isoformat()
+
+
+class RatingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Rating
+        fields = ('user', 'article_id', 'score')

--- a/authors/apps/articles/tests/base_test.py
+++ b/authors/apps/articles/tests/base_test.py
@@ -45,6 +45,10 @@ class BaseTest(APITestCase):
             }
         }
 
+        self.rate_article = {
+            'rating': 5
+        }
+
         user = User.objects.get()
         request = self.request
         token, uid = RegistrationAPIView.generate_token(user, request)
@@ -56,12 +60,13 @@ class BaseTest(APITestCase):
         response = self.client.post(
             '/api/users/login/',
             self.user_data,
-            format='json')
+            format='json'
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.login_token = response.data['token']
         self.client.credentials(
-            HTTP_AUTHORIZATION='Bearer ' +
-            self.login_token)
+            HTTP_AUTHORIZATION='Bearer ' + self.login_token
+        )
 
     def account_verification(self, token, uid):
         request = APIRequestFactory().get(

--- a/authors/apps/articles/tests/test_ratings.py
+++ b/authors/apps/articles/tests/test_ratings.py
@@ -1,0 +1,29 @@
+from rest_framework.test import APIClient
+from .base_test import BaseTest
+from rest_framework import status
+
+
+class TestRatings(BaseTest):
+    def test_api_can_rate_an_article(self):
+        slug = self.get_slug()
+        response = self.client.post(
+            '/api/articles/{}/ratings/'.format(slug),
+            data=self.rate_article, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+    
+    def test_api_returns_404_for_non_existent_slug(self):
+        response = self.client.post(
+            '/api/articles/slug/ratings/',
+            data=self.rate_article,
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    
+    def test_api_returns_error_for_ratings_not_from_1_to_5(self):
+        slug = self.get_slug()
+        response = self.client.post(
+            '/api/articles/{}/ratings/'.format(slug),
+            data={'rating': -3}, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,10 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from .views import ArticleViewSet, ArticleRetrieve
+from .views import ArticleViewSet, ArticleRetrieve, RatingsView
 
 
 urlpatterns = [
     path('articles/', ArticleViewSet.as_view()),
-    path('articles/<slug>', ArticleRetrieve.as_view())
+    path('articles/<slug>', ArticleRetrieve.as_view()),
+    path('articles/<slug>/ratings/', RatingsView.as_view()),
 ]

--- a/authors/apps/authentication/tests/test_auth.py
+++ b/authors/apps/authentication/tests/test_auth.py
@@ -30,7 +30,18 @@ class AuthTestCase(APITestCase):
         )
         verify = AccountVerified.as_view()
         response = verify(request, token=token, uid=uid)
-        return response 
+        return response
+    
+    def test_api_returns_error_when_registering_with_invalid_data(self):
+        user_data = {
+            'user': {
+                'username': '',
+                'email': 'user@gmail.com',
+                'password': 'Bl4ckP@nther'
+            }
+        }
+        response = self.client.post('/api/users/', data=user_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_token_received_after_successful_registration(self):
         """


### PR DESCRIPTION
### What does this PR do?
Adds a functionality that enables registered users to rate articles
#### Description of task to be completed?
- Add Rating model to articles app
- Add serializer for the Rating model
- Add API view to rate articles
- Write tests for implemented code
#### How should this be manually tested?
- Get all articles to expose their slugs (GET /api/articles/)
- Rate an article by copying its slug and hitting the endpoint: POST /api/articles/\<slug\>/ratings/
  - The POST data should have the format: {'rating': \<score\>}
  - \<score\> must be a number from 1 to 5
- GET /api/articles/ to verify that the article's rating has been modified
#### What are the relevant pivotal tracker stories
[#162163171](https://www.pivotaltracker.com/n/projects/2227671/stories/162163171)