### PR TITLE
#162163173 Users should be able to like and or dislike articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from authors.apps.authentication.models import User
 from authors.apps.core.models import TimestampedModel
 
 
@@ -19,6 +20,40 @@ class Article(TimestampedModel):
         'profiles.UserProfile',
         on_delete=models.CASCADE,
         related_name='articles')
+    likes = models.IntegerField(
+        db_index=True,
+        default=False
+    )
+    dislikes = models.IntegerField(
+        db_index=True,
+        default=False
+    )
 
     def __str__(self):
         return self.title
+
+
+class Impressions(TimestampedModel):
+    """
+    Create an `Impression` with a slug, user details, likes and dislikes.
+    """
+
+    slug = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        to_field="slug",
+        db_column="slug"
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+    )
+    likes = models.BooleanField(
+        db_index=True,
+        default=None
+    )
+    dislikes = models.BooleanField(
+        db_index=True,
+        default=None
+    )
+

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
-
-from authors.apps.profiles.serializers import GetUserProfileSerializer
-
-from .models import Article
+from authors.apps.profiles.serializers import (
+    GetUserProfileSerializer)
+from .models import (
+    Article, Impressions)
 
 
 class ArticleSerializer(serializers.ModelSerializer):
@@ -26,6 +26,8 @@ class ArticleSerializer(serializers.ModelSerializer):
             'slug',
             'title',
             'updatedAt',
+            'likes',
+            'dislikes'
         )
 
     def create(self, validated_data):
@@ -40,3 +42,32 @@ class ArticleSerializer(serializers.ModelSerializer):
     def get_updated_at(self, instance):
 
         return instance.updated_at.isoformat()
+
+
+class ImpressionSerializer(serializers.ModelSerializer):
+    """
+    Serializes impressions requests and adds to an Article.
+    """
+
+    createdAt = serializers.SerializerMethodField(method_name='get_created_at')
+    updatedAt = serializers.SerializerMethodField(method_name='get_updated_at')
+
+    class Meta:
+        model = Impressions
+        fields = (
+            'slug',
+            'user',
+            'likes',
+            'dislikes',
+            'updatedAt',
+            'createdAt',
+        )
+
+    def get_created_at(self, instance):
+
+        return instance.created_at.isoformat()
+
+    def get_updated_at(self, instance):
+
+        return instance.updated_at.isoformat()
+

--- a/authors/apps/articles/tests/test_impressions.py
+++ b/authors/apps/articles/tests/test_impressions.py
@@ -1,0 +1,78 @@
+from rest_framework.test import APIClient
+from .base_test import BaseTest
+from rest_framework import status
+
+
+class Test_Impression(BaseTest):
+
+    def test_add_like_impression(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        reponse = self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_201_CREATED)
+
+    def test_add_dislike_impression(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        reponse = self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.article_without_title,
+            format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_201_CREATED)
+
+    def test_user_is_neutral_after_liking_twice(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)
+
+
+    def test_user_can_not_dislike_and_like_an_article(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)
+
+    
+    def test_user_can_not_like_and_dislike_an_article(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,13 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from .views import ArticleViewSet, ArticleRetrieve
+from .views import (
+    ArticleViewSet, ArticleRetrieve,
+    LikeArticle, DislikeArticle)
 
 
 urlpatterns = [
     path('articles/', ArticleViewSet.as_view()),
-    path('articles/<slug>', ArticleRetrieve.as_view())
+    path('articles/<slug>', ArticleRetrieve.as_view()),
+    path('articles/like/<slug>', LikeArticle.as_view()),
+    path('articles/dislike/<slug>', DislikeArticle.as_view())
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,13 +1,18 @@
 from rest_framework import mixins, status, viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import (
+    IsAuthenticatedOrReadOnly, IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
     ListCreateAPIView)
-from .models import Article
+from .models import (
+    Article, Impressions)
 from .renderers import ArticleJSONRenderer
-from .serializers import ArticleSerializer
+from .serializers import (
+    ArticleSerializer, ImpressionSerializer)
+from ..authentication.models import User
+from django.db.models import Count
 
 
 class ArticleViewSet(ListCreateAPIView):
@@ -73,5 +78,105 @@ class ArticleRetrieve(RetrieveUpdateDestroyAPIView):
             raise NotFound('An article with this slug does not exist.')
         self.perform_destroy(serializer_instance)
         return Response(
-            "Article successfully deleted! ",
+            "Article successfully deleted!",
             status=status.HTTP_204_NO_CONTENT)
+
+
+class LikeArticle(ListCreateAPIView):
+    """
+    article like view
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, slug):
+        user = User.objects.get(username=request.user.username)
+
+        impression = {
+            'user': user.id,
+            'likes': True,
+            'dislikes': False,
+            'slug': slug
+        }
+        self.updateimpression(impression)
+        try:
+            impression = Impressions.objects.all().filter(slug=slug, likes=True)
+            total_likes = impression.aggregate(Count('likes'))
+            article = Article.objects.get(slug=slug)
+            article.likes = total_likes['likes__count']
+            article.save()
+        except Article.DoesNotExist:
+            raise NotFound('An article with this slug does not exist.')
+        return Response(
+            {'i like this article'},
+            status=status.HTTP_201_CREATED)
+
+    def updateimpression(self, impression):
+        try:
+            item = Impressions.objects.filter(
+                user = impression['user'],
+                slug = impression['slug']
+            )[0]
+            if item.likes == True:
+                item.likes = False
+            elif item.likes == False and item.dislikes == True:
+                item.likes = True
+                item.dislikes = False
+            item.save()
+        except:
+            serializer = ImpressionSerializer(
+                data=impression
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+
+
+class DislikeArticle(ListCreateAPIView):
+    """
+    article dislike view
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, slug):
+        user = User.objects.get(username=request.user.username)
+
+        impression = {
+            'user': user.id,
+            'likes': False,
+            'dislikes': True,
+            'slug': slug
+        }
+
+        self.updateimpression(impression)
+        try:
+            impression = Impressions.objects.all().filter(slug=slug, dislikes=True)
+            total_dislikes = impression.aggregate(Count('dislikes'))
+            article = Article.objects.get(slug=slug)
+            article.dislikes = total_dislikes['dislikes__count']
+            article.save()
+        except Article.DoesNotExist:
+            raise NotFound('An article with this slug does not exist.')
+        return Response(
+            {'i dislike this article'},
+            status=status.HTTP_201_CREATED)
+
+    def updateimpression(self, impression):
+        try:
+            item = Impressions.objects.filter(
+                user = impression['user'],
+                slug = impression['slug']
+            )[0]
+            if item.dislikes == True:
+                item.dislikes = False
+            elif item.dislikes == False and item.likes == True:
+                item.dislikes = True
+                item.likes = False
+            item.save()
+        except:
+            serializer = ImpressionSerializer(
+                data=impression
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+

--- a/authors/apps/authentication/tests/test_user_verification.py
+++ b/authors/apps/authentication/tests/test_user_verification.py
@@ -43,6 +43,24 @@ class TestUserVerification(APITestCase):
         response = self.client.post('/api/users/' ,data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn ("{'message': 'User successfully Registered, check your email and click the link to verify'}", str(response.data) )
+
+    def test_for_new_user_without_email(self):
+        """
+        Method for testing registration of a new user without an email.
+        """
+        data = {"user": { "username":"lindsey1", "email": "", "password":"Lindseypatra1/"}}
+        response = self.client.post('/api/users/' ,data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert 'errors' in response.data
+        
+    def test_for_new_user_without_username(self):
+        """
+        Method for testing registration of a new user without a username.
+        """
+        data = {"user": { "username":"", "email": "lindsey1@gmail.com", "password":"Lindseypatra1/"}}
+        response = self.client.post('/api/users/' ,data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert 'errors' in response.data
     
     def test_login_unverified_user(self):
         """
@@ -62,3 +80,4 @@ class TestUserVerification(APITestCase):
         response = self.client.post('/api/users/login/',self.user_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK) 
         assert 'token' in response.data
+


### PR DESCRIPTION
**What does this PR do?**
This Pull Request adds the following functionality to the articles app:
	•	Users can like articles
	•	Users can dislike articles

**Description of Task to be completed?**
Currently, users can only create an article, get all articles, get a specific article, update an article and delete an article. This task adds the ability for any registered user to like or dislike any articles available.

**How should this be manually tested?**
	•	Make migrations: `./manage.py make migrations`
	•	Migrate: `./manage.py migrate`
	•	Run the server: `./manage.py runserver`
	•	Open postman and test these endpoints:

**Like an article** 
POST `http://127.0.0.1:8000/api/articles/like/<slug>`

**Dislike an article**
 POST `http://127.0.0.1:8000/api/articles/dislike/<slug>`

**What are the relevant pivotal tracker stories?**
[#162163170](https://www.pivotaltracker.com/story/show/162163170)

**Any background context you want to add?**
You don’t need a body when using these endpoints so add the slug to add the like or dislike to a particular article once the user sends a post to the like endpoint the functionality will be triggered.

**Screenshots (if appropriate)**
when the like endpoint is accessed:
<img width="732" alt="screen shot 2018-12-13 at 5 36 29 pm" src="https://user-images.githubusercontent.com/9946845/49948108-d2b71a00-ff03-11e8-9d7e-f9deb9a3954a.png">

when the article is fetched showing the count:
<img width="1078" alt="screen shot 2018-12-13 at 5 36 15 pm" src="https://user-images.githubusercontent.com/9946845/49948132-e3679000-ff03-11e8-8966-601ab1d57d48.png">
