### PR TITLE
#162163173 Fix users unable to see likes and dislikes in articles:

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from authors.apps.profiles.models import UserProfile
+from authors.apps.authentication.models import User
 from authors.apps.core.models import TimestampedModel
 from django.contrib.postgres.fields import ArrayField
 from ..profiles.models import UserProfile
@@ -23,6 +24,14 @@ class Article(TimestampedModel):
         related_name='articles')
     score = models.FloatField(default=0)
     images = ArrayField(models.URLField(max_length=255),default=list)
+    likes = models.IntegerField(
+        db_index=True,
+        default=False
+    )
+    dislikes = models.IntegerField(
+        db_index=True,
+        default=False
+    )
 
     def __str__(self):
         return self.title
@@ -35,3 +44,29 @@ class Rating(models.Model):
     user = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
     article_id = models.ForeignKey(Article, on_delete=models.CASCADE)
     score = models.IntegerField()
+
+    
+class Impressions(TimestampedModel):
+    """
+    Create an `Impression` with a slug, user details, likes and dislikes.
+    """
+
+    slug = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        to_field="slug",
+        db_column="slug"
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+    )
+    likes = models.BooleanField(
+        db_index=True,
+        default=None
+    )
+    dislikes = models.BooleanField(
+        db_index=True,
+        default=None
+    )
+

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,6 +1,10 @@
 from rest_framework import serializers
 from authors.apps.profiles.serializers import GetUserProfileSerializer
 from .models import Article, Rating
+from authors.apps.profiles.serializers import (
+    GetUserProfileSerializer)
+from .models import (
+    Article, Impressions)
 
 
 class ArticleSerializer(serializers.ModelSerializer):
@@ -18,7 +22,8 @@ class ArticleSerializer(serializers.ModelSerializer):
         model = Article
         fields = (
             'author', 'body', 'createdAt', 'description',
-            'slug', 'title', 'updatedAt', 'score', 'images'
+            'slug', 'title', 'updatedAt', 'score', 'images',
+            'likes', 'dislikes'
         )
 
     def create(self, validated_data):
@@ -36,5 +41,32 @@ class RatingSerializer(serializers.ModelSerializer):
     class Meta:
         model = Rating
         fields = ('user', 'article_id', 'score')
+
+class ImpressionSerializer(serializers.ModelSerializer):
+    """
+    Serializes impressions requests and adds to an Article.
+    """
+
+    createdAt = serializers.SerializerMethodField(method_name='get_created_at')
+    updatedAt = serializers.SerializerMethodField(method_name='get_updated_at')
+
+    class Meta:
+        model = Impressions
+        fields = (
+            'slug',
+            'user',
+            'likes',
+            'dislikes',
+            'updatedAt',
+            'createdAt',
+        )
+
+    def get_created_at(self, instance):
+
+        return instance.created_at.isoformat()
+
+    def get_updated_at(self, instance):
+
+        return instance.updated_at.isoformat()
 
 

--- a/authors/apps/articles/tests/test_impressions.py
+++ b/authors/apps/articles/tests/test_impressions.py
@@ -1,0 +1,78 @@
+from rest_framework.test import APIClient
+from .base_test import BaseTest
+from rest_framework import status
+
+
+class Test_Impression(BaseTest):
+
+    def test_add_like_impression(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        reponse = self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_201_CREATED)
+
+    def test_add_dislike_impression(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        reponse = self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.article_without_title,
+            format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_201_CREATED)
+
+    def test_user_is_neutral_after_liking_twice(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)
+
+
+    def test_user_can_not_dislike_and_like_an_article(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)
+
+    
+    def test_user_can_not_like_and_dislike_an_article(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        self.client.post(
+            '/api/articles/like/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        self.client.post(
+            '/api/articles/dislike/{}'.format(slug),
+            data=self.new_article,
+            format='json')
+        reponse = self.client.get('/api/articles/', format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,10 +1,14 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from .views import ArticleViewSet, ArticleRetrieve, RatingsView
+from .views import (
+    ArticleViewSet, ArticleRetrieve,
+    LikeArticle, DislikeArticle, RatingsView)
 
 
 urlpatterns = [
     path('articles/', ArticleViewSet.as_view()),
     path('articles/<slug>', ArticleRetrieve.as_view()),
     path('articles/<slug>/ratings/', RatingsView.as_view()),
+    path('articles/like/<slug>', LikeArticle.as_view()),
+    path('articles/dislike/<slug>', DislikeArticle.as_view())
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -17,8 +17,22 @@ from .renderers import ArticleJSONRenderer
 from .serializers import ArticleSerializer, RatingSerializer
 from .pagination import PageNumbering
 from django.db.models import Avg
-from authors.apps.authentication.models import User
 from authors.apps.profiles.models import UserProfile
+from rest_framework.permissions import (
+    IsAuthenticatedOrReadOnly, IsAuthenticated)
+from rest_framework.response import Response
+from rest_framework.exceptions import NotFound
+from rest_framework.generics import (
+    RetrieveUpdateDestroyAPIView,
+    ListCreateAPIView)
+from .models import (
+    Article, Impressions)
+from .renderers import ArticleJSONRenderer
+from .serializers import (
+    ArticleSerializer, ImpressionSerializer,
+    RatingSerializer)
+from ..authentication.models import User
+from django.db.models import Count
 
 
 class ArticleViewSet(ListCreateAPIView):
@@ -79,8 +93,9 @@ class ArticleRetrieve(RetrieveUpdateDestroyAPIView):
         except Article.DoesNotExist: 
             raise NotFound('An article with this slug does not exist.')
 
+        self.perform_destroy(serializer_instance)
         return Response(
-            "The Article has been successfully deleted",
+            "Article successfully deleted!",
             status=status.HTTP_204_NO_CONTENT)
 
 
@@ -131,3 +146,103 @@ class RatingsView(APIView):
         article = Article.objects.filter(id=article_id)[0]
         article.score = round(average['score__avg'], 1)
         article.save()
+
+
+class LikeArticle(ListCreateAPIView):
+    """
+    article like view
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, slug):
+        user = User.objects.get(username=request.user.username)
+
+        impression = {
+            'user': user.id,
+            'likes': True,
+            'dislikes': False,
+            'slug': slug
+        }
+        self.updateimpression(impression)
+        try:
+            impression = Impressions.objects.all().filter(slug=slug, likes=True)
+            total_likes = impression.aggregate(Count('likes'))
+            article = Article.objects.get(slug=slug)
+            article.likes = total_likes['likes__count']
+            article.save()
+        except Article.DoesNotExist:
+            raise NotFound('An article with this slug does not exist.')
+        return Response(
+            {'message': 'i like this article.'},
+            status=status.HTTP_201_CREATED)
+
+    def updateimpression(self, impression):
+        try:
+            item = Impressions.objects.filter(
+                user = impression['user'],
+                slug = impression['slug']
+            )[0]
+            if item.likes == True:
+                item.likes = False
+            elif item.likes == False and item.dislikes == True:
+                item.likes = True
+                item.dislikes = False
+            item.save()
+        except:
+            serializer = ImpressionSerializer(
+                data=impression
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+
+
+class DislikeArticle(ListCreateAPIView):
+    """
+    article dislike view
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, slug):
+        user = User.objects.get(username=request.user.username)
+
+        impression = {
+            'user': user.id,
+            'likes': False,
+            'dislikes': True,
+            'slug': slug
+        }
+
+        self.updateimpression(impression)
+        try:
+            impression = Impressions.objects.all().filter(slug=slug, dislikes=True)
+            total_dislikes = impression.aggregate(Count('dislikes'))
+            article = Article.objects.get(slug=slug)
+            article.dislikes = total_dislikes['dislikes__count']
+            article.save()
+        except Article.DoesNotExist:
+            raise NotFound('An article with this slug does not exist.')
+        return Response(
+            {'message': 'i dislike this article'},
+            status=status.HTTP_201_CREATED)
+
+    def updateimpression(self, impression):
+        try:
+            item = Impressions.objects.filter(
+                user = impression['user'],
+                slug = impression['slug']
+            )[0]
+            if item.dislikes == True:
+                item.dislikes = False
+            elif item.dislikes == False and item.likes == True:
+                item.dislikes = True
+                item.likes = False
+            item.save()
+        except:
+            serializer = ImpressionSerializer(
+                data=impression
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+

--- a/authors/apps/authentication/tests/test_user_verification.py
+++ b/authors/apps/authentication/tests/test_user_verification.py
@@ -43,6 +43,24 @@ class TestUserVerification(APITestCase):
         response = self.client.post('/api/users/' ,data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn ("{'message': 'User successfully Registered, check your email and click the link to verify'}", str(response.data) )
+
+    def test_for_new_user_without_email(self):
+        """
+        Method for testing registration of a new user without an email.
+        """
+        data = {"user": { "username":"lindsey1", "email": "", "password":"Lindseypatra1/"}}
+        response = self.client.post('/api/users/' ,data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert 'errors' in response.data
+        
+    def test_for_new_user_without_username(self):
+        """
+        Method for testing registration of a new user without a username.
+        """
+        data = {"user": { "username":"", "email": "lindsey1@gmail.com", "password":"Lindseypatra1/"}}
+        response = self.client.post('/api/users/' ,data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert 'errors' in response.data
     
     def test_login_unverified_user(self):
         """
@@ -62,3 +80,4 @@ class TestUserVerification(APITestCase):
         response = self.client.post('/api/users/login/',self.user_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK) 
         assert 'token' in response.data
+

--- a/authors/apps/social_auth_login/tests/test_social.py
+++ b/authors/apps/social_auth_login/tests/test_social.py
@@ -38,7 +38,7 @@ class SocialTests(APITestCase):
 
     def test_login_with_invalid_google_token(self):
         """
-        Test if a user can login with an invalid or expired google token 
+        Test if a user can login with an invalid or expired google token
         """
 
         response = self.client.post(
@@ -46,7 +46,8 @@ class SocialTests(APITestCase):
             self.user_with_invalid_or_expired_google_token, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
-            'The token is invalid or expired. Please login again.', str(response.data))
+            'The token is invalid or expired. Please login again.', str(
+                response.data))
 
     def test_login_with_invalid_or_expired_google_token(self):
         """
@@ -58,18 +59,22 @@ class SocialTests(APITestCase):
             self.user_with_invalid_or_expired_google_token, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
-            'The token is invalid or expired. Please login again.', str(response.data))
+            'The token is invalid or expired. Please login again.', str(
+                response.data))
 
     def test_login_with_invalid_facebook_token(self):
         """
-        Test if a user can login with an invalid or expired facebook token 
+        Test if a user can login with an invalid or expired facebook token
         """
 
         response = self.client.post(
-            "/api/social/auth/facebook/", self.user_with_invalid_or_expired_facebook_token, format='json')
+            "/api/social/auth/facebook/",
+            self.user_with_invalid_or_expired_facebook_token,
+            format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
-            'The token is invalid or expired. Please login again.', str(response.data))
+            'The token is invalid or expired. Please login again.', str(
+                response.data))
 
     def test_login_with_invalid_or_expired_facebook_token(self):
         """
@@ -93,4 +98,5 @@ class SocialTests(APITestCase):
             self.user_with_invalid_or_expired_twitter_token, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
-            'The token is invalid or expired. Please login again.', str(response.data))
+            'The token is invalid or expired. Please login again.', str(
+                response.data))


### PR DESCRIPTION
**What does this PR do?**
Change Article serializer on view for articles list to display likes and dislikes.

**Description of Task to be completed?**
Apparently, users are not able to view the likes and dislikes an articles has because the Article serializer doesn't include those fields. This PR fixes this bug by adding those fields to the ArticlesSerializer.

**How should this be manually tested?**
Make migrations: .`/manage.py makemigrations`
Migrate: `./manage.py migrate`
Run the server: `./manage.py runserver`

**Like an article** 
POST `http://127.0.0.1:8000/api/articles/like/<slug>`

**Dislike an article**
 POST `http://127.0.0.1:8000/api/articles/dislike/<slug>`

**What are the relevant pivotal tracker stories?**
[#162163170](https://www.pivotaltracker.com/story/show/162163173)

**Any background context you want to add?**
You don’t need a body when using these endpoints so add the slug to add the like or dislike to a particular article once the user sends a post to the like endpoint the functionality will be triggered.

Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/9946845/50149871-65253800-02cd-11e9-8dd8-d003e0f1a5b2.png)
