### PR TITLE
#162163173 Fix users unable to see likes and dislikes in articles

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -22,7 +22,8 @@ class ArticleSerializer(serializers.ModelSerializer):
         model = Article
         fields = (
             'author', 'body', 'createdAt', 'description',
-            'slug', 'title', 'updatedAt', 'score', 'images'
+            'slug', 'title', 'updatedAt', 'score', 'images',
+            'likes', 'dislikes'
         )
 
     def create(self, validated_data):


### PR DESCRIPTION
**What does this PR do?**
Change Article serializer on view for articles list to display likes and dislikes.

**Description of Task to be completed?**
Apparently, users are not able to view the likes and dislikes an articles has because the Article serializer doesn't include those fields. This PR fixes this bug by adding those fields to the ArticlesSerializer.

**How should this be manually tested?**
Make migrations: .`/manage.py makemigrations`
Migrate: `./manage.py migrate`
Run the server: `./manage.py runserver`

**Like an article** 
POST `http://127.0.0.1:8000/api/articles/like/<slug>`

**Dislike an article**
 POST `http://127.0.0.1:8000/api/articles/dislike/<slug>`

**What are the relevant pivotal tracker stories?**
[#162163170](https://www.pivotaltracker.com/story/show/162163173)

**Any background context you want to add?**
You don’t need a body when using these endpoints so add the slug to add the like or dislike to a particular article once the user sends a post to the like endpoint the functionality will be triggered.

Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/9946845/50149871-65253800-02cd-11e9-8dd8-d003e0f1a5b2.png)
