### PR TITLE
 #162163178 Users should be able to tag their articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -9,7 +9,8 @@ from authors.apps.authentication.models import User
 
 class Article(TimestampedModel):
     """
-    Create and return an `Article` with a title, description and body.
+    Create and return an `Article` with a title, 
+    description, body and tags associated with the article.
     """
     slug = models.SlugField(
         db_index=True,
@@ -24,7 +25,7 @@ class Article(TimestampedModel):
         on_delete=models.CASCADE,
         related_name='articles')
     score = models.FloatField(default=0)
-    images = ArrayField(models.URLField(max_length=255),default=list)
+    images = ArrayField(models.URLField(max_length=255), default=list)
     likes = models.IntegerField(
         db_index=True,
         default=False
@@ -32,6 +33,9 @@ class Article(TimestampedModel):
     dislikes = models.IntegerField(
         db_index=True,
         default=False
+    )
+    tags = models.ManyToManyField(
+        'articles.Tag', related_name='articles'
     )
 
     def __str__(self):
@@ -46,7 +50,7 @@ class Rating(models.Model):
     article_id = models.ForeignKey(Article, on_delete=models.CASCADE)
     score = models.IntegerField()
 
-    
+
 class Impressions(TimestampedModel):
     """
     Create an `Impression` with a slug, user details, likes and dislikes.
@@ -78,6 +82,17 @@ class Report(models.Model):
     reported = models.BooleanField(default=False)
     reported_at = models.DateTimeField(auto_now_add=True)
     reason = models.CharField(max_length=500, blank=False)
-    
+
     def __str__(self):
         return self.reason
+
+
+class Tag(TimestampedModel):
+    """
+    Tag Model to allow authors add tags to their articles they create
+    """
+    tag = models.CharField(max_length=255)
+    slug = models.SlugField(db_index=True, unique=True)
+
+    def __str__(self):
+        return self.tag

--- a/authors/apps/articles/relations.py
+++ b/authors/apps/articles/relations.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from .models import Tag
+
+
+class TagRelatedField(serializers.RelatedField):
+    """
+    A Special Serializer field for Tags.
+    If a user tags an article with an non existing tag, that new tag will also be created on article creation
+    """
+
+    def get_queryset(self):
+        return Tag.objects.all()
+
+    def to_internal_value(self, data):
+        tag, created = Tag.objects.get_or_create(tag=data, slug=data.lower())
+        return tag
+
+    def to_representation(self, value):
+        """
+        Return a tag property
+        """
+        return value.tag

--- a/authors/apps/articles/tests/test_tag_article.py
+++ b/authors/apps/articles/tests/test_tag_article.py
@@ -1,0 +1,20 @@
+from rest_framework.test import APIClient
+from .base_test import BaseTest
+from rest_framework import status
+
+
+class TestTagArticle(BaseTest):
+    def test_create_article_with_tags(self):
+        reponse = self.client.post(
+            '/api/articles/',
+            data={
+                "article": {
+                    "title": "How to fight dragons 8",
+                    "description": "Ever wonder jckvlahvhow?",
+                    "body": "You have kenglto believe",
+                    "tagList": ["dragons", "fight"]
+                }
+            },
+            format='json')
+        self.assertEqual(reponse.status_code, status.HTTP_201_CREATED)
+

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -2,8 +2,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 from .views import (
     ArticleViewSet, ArticleRetrieve,
-    LikeArticle, DislikeArticle, RatingsView, ReportArticlesView)
-
+    LikeArticle, DislikeArticle, RatingsView, ReportArticlesView, TagListView)
 
 urlpatterns = [
     path('articles/', ArticleViewSet.as_view()),
@@ -11,5 +10,6 @@ urlpatterns = [
     path('articles/<slug>/ratings/', RatingsView.as_view()),
     path('articles/like/<slug>', LikeArticle.as_view()),
     path('articles/dislike/<slug>', DislikeArticle.as_view()),
-    path('<slug>/report_article', ReportArticlesView.as_view())
+    path('<slug>/report_article', ReportArticlesView.as_view()),
+    path('tags', TagListView.as_view()),
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,36 +1,20 @@
 from rest_framework import mixins, status, viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.exceptions import NotFound
-from rest_framework.generics import (
-    RetrieveUpdateDestroyAPIView, RetrieveUpdateAPIView,
-    ListCreateAPIView)
-from .models import Article
-from authors.apps.profiles.models import UserProfile
-from rest_framework.generics import (
-    RetrieveUpdateDestroyAPIView, RetrieveUpdateAPIView,
-    ListCreateAPIView)
 from rest_framework.views import APIView
-from .models import Article, Rating
-
-from .renderers import ArticleJSONRenderer
-from .serializers import ArticleSerializer, RatingSerializer
-from .pagination import PageNumbering
-from django.db.models import Avg
-from authors.apps.profiles.models import UserProfile
-from rest_framework.permissions import (
-    IsAuthenticatedOrReadOnly, IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import (
-    RetrieveUpdateDestroyAPIView,
-    ListCreateAPIView)
+    RetrieveUpdateDestroyAPIView, RetrieveUpdateAPIView,
+    ListCreateAPIView, ListAPIView)
 from .models import (
-    Article, Impressions, Report)
+    Article, Impressions, Rating, Report, Tag)
 from .renderers import ArticleJSONRenderer
 from .serializers import (
     ArticleSerializer, ImpressionSerializer,
-    RatingSerializer, ArticleReportSerializer)
+    RatingSerializer, ArticleReportSerializer, TagSerializer)
+from .pagination import PageNumbering
+from django.db.models import Avg
+from authors.apps.profiles.models import UserProfile
 from ..authentication.models import User
 from django.db.models import Count
 
@@ -320,3 +304,17 @@ class ReportArticlesView(generics.GenericAPIView):
                   receipient], fail_silently=False)
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class TagListView(ListAPIView):
+    queryset = Tag.objects.all()
+    permission_classes = (IsAuthenticated,)
+    serializer_class = TagSerializer
+
+    def taglist(self, request):
+        serializer_data = self.get_queryset()
+        serializer = self.serializer_class(serializer_data, many=True)
+
+        return Response({
+            'tags': serializer_data
+        }, status=status.HTTP_200_OK)


### PR DESCRIPTION
### What does this PR do?
The PR Adds functionality to enable authors to tag their articles
#### How should this be manually tested?
During article creation, the user will be able to tag his/her article

Article Creation
```
POST http://localhost:8000/api/articles/
{
	"article": {
		"title": "Blog Like a Pro",
		"description": "Sam's introduction to blogging in 24hrs - PacktPub",
		"body": "Blogger is awesome, as a blogger, you write 24/7, Really!",
		"tagList": ["blogger, "PacktPub", "Pro"],
		"images": ["http://zeus.com/awsome_me.png"]
	}
}
```

#### What are the relevant pivotal tracker stories?
 [#162163178](https://www.pivotaltracker.com/story/show/162163178)

