### PR TITLE
 #162163170 Fix logic to unable users like and dislike articles

### DIFF
--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -50,6 +50,16 @@ class Test_article(BaseTest):
             format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
+    def test_update_article_doesnot_exist(self):
+        self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+
+        response = self.client.put(
+            '/api/articles/blahblahblah',
+            data=self.update_article,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_delete_article(self):
         created_article = self.client.post(
             '/api/articles/', data=self.new_article, format='json')

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -168,8 +168,11 @@ class LikeArticle(ListCreateAPIView):
         try:
             impression = Impressions.objects.all().filter(slug=slug, likes=True)
             total_likes = impression.aggregate(Count('likes'))
+            impression = Impressions.objects.all().filter(slug=slug, dislikes=True)
+            total_dislikes = impression.aggregate(Count('dislikes'))
             article = Article.objects.get(slug=slug)
             article.likes = total_likes['likes__count']
+            article.dislikes = total_dislikes['dislikes__count']
             article.save()
         except Article.DoesNotExist:
             raise NotFound('An article with this slug does not exist.')
@@ -185,7 +188,8 @@ class LikeArticle(ListCreateAPIView):
             )[0]
             if item.likes == True:
                 item.likes = False
-            elif item.likes == False and item.dislikes == True:
+                item.dislikes = False
+            else:
                 item.likes = True
                 item.dislikes = False
             item.save()
@@ -216,9 +220,12 @@ class DislikeArticle(ListCreateAPIView):
 
         self.updateimpression(impression)
         try:
+            impression = Impressions.objects.all().filter(slug=slug, likes=True)
+            total_likes = impression.aggregate(Count('likes'))
             impression = Impressions.objects.all().filter(slug=slug, dislikes=True)
             total_dislikes = impression.aggregate(Count('dislikes'))
             article = Article.objects.get(slug=slug)
+            article.likes = total_likes['likes__count']
             article.dislikes = total_dislikes['dislikes__count']
             article.save()
         except Article.DoesNotExist:
@@ -235,7 +242,8 @@ class DislikeArticle(ListCreateAPIView):
             )[0]
             if item.dislikes == True:
                 item.dislikes = False
-            elif item.dislikes == False and item.likes == True:
+                item.likes = False
+            else:
                 item.dislikes = True
                 item.likes = False
             item.save()
@@ -245,4 +253,3 @@ class DislikeArticle(ListCreateAPIView):
             )
             serializer.is_valid(raise_exception=True)
             serializer.save()
-


### PR DESCRIPTION
**What does this PR do?**
Change Article logic for users to like and dislike articles.

**Description of Task to be completed?**
Apparently, users are able to like and dislike an article yet ideally a user should be able to only either like or dislike an article. This PR fixes this bug by changing the logic.

**How should this be manually tested?**
Make migrations: .`/manage.py makemigrations`
Migrate: `./manage.py migrate`
Run the server: `./manage.py runserver`

**Like an article** 
POST `http://127.0.0.1:8000/api/articles/like/<slug>`

**Dislike an article**
 POST `http://127.0.0.1:8000/api/articles/dislike/<slug>`

**What are the relevant pivotal tracker stories?**
[#162163170](https://www.pivotaltracker.com/story/show/162163173)

**Any background context you want to add?**
You don’t need a body when using these endpoints so add the slug to add the like or dislike to a particular article once the user sends a post to the like endpoint the functionality will be triggered.

Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/9946845/50149871-65253800-02cd-11e9-8dd8-d003e0f1a5b2.png)
