### PR TITLE
#162163182 Allow authenticated users to share articles 

### DIFF
--- a/authors/apps/articles/pagination.py
+++ b/authors/apps/articles/pagination.py
@@ -2,4 +2,4 @@ from rest_framework.pagination import LimitOffsetPagination
 
 class PageNumbering(LimitOffsetPagination):
     default_limit = 10
-    max_limit = 20
+    max_limit = 100

--- a/authors/apps/articles/tests/test_sharing.py
+++ b/authors/apps/articles/tests/test_sharing.py
@@ -1,0 +1,59 @@
+from rest_framework.test import APIClient
+from .base_test import BaseTest
+from rest_framework import status
+
+
+
+class TestSharing(BaseTest):
+    def test_api_can_share_an_article_on_facebook(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        response = self.client.post(
+            '/api/articles/{}/facebook/'.format(slug),
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_api_can_share_an_article_with_facebook_with_wrong_slug(self):
+        response = self.client.post(
+            '/api/articles/slug/facebook/',
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    
+    def test_api_can_share_an_article_on_twitter(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        response = self.client.post(
+            '/api/articles/{}/twitter/'.format(slug),
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_api_can_share_an_article_with_twitter_with_wrong_slug(self):
+        response = self.client.post(
+            '/api/articles/slug/twitter/',
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+    def test_api_can_share_an_article_with_email(self):
+        created_article = self.client.post(
+            '/api/articles/', data=self.new_article, format='json')
+        slug = self.get_slug(created_article)
+
+        response = self.client.post(
+            '/api/articles/{}/email/'.format(slug),
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_api_can_share_an_article_with_email_with_wrong_slug(self):
+        response = self.client.post(
+            '/api/articles/slug/email/'
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -2,7 +2,10 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 from .views import (
     ArticleViewSet, ArticleRetrieve,
-    LikeArticle, DislikeArticle, RatingsView, ReportArticlesView, TagListView,BookMarkView,BookMarkArticleView)
+    LikeArticle, DislikeArticle, RatingsView, ReportArticlesView, 
+    TagListView, FacebookShareView, TwitterShareView, EmailShareView,
+    BookMarkView, BookMarkArticleView
+)
 
 
 urlpatterns = [
@@ -14,6 +17,8 @@ urlpatterns = [
     path('<slug>/report_article', ReportArticlesView.as_view()),
     path('tags', TagListView.as_view()),
     path('articles/bookmark/<slug>', BookMarkArticleView.as_view()),
-    path('articles/bookmark/', BookMarkView.as_view())
-    
+    path('articles/bookmark/', BookMarkView.as_view()),
+    path('articles/<slug>/facebook/', FacebookShareView.as_view()),
+    path('articles/<slug>/twitter/', TwitterShareView.as_view()),
+    path('articles/<slug>/email/', EmailShareView.as_view()),
 ]

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,18 +1,15 @@
 from django.urls import path
-from rest_framework_swagger.views import get_swagger_view
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView, AccountVerified, 
     PasswordResetAPIView, PasswordUpdateAPIView, UsersRetrieveAPIView
 )
 
-schema_view = get_swagger_view(title='Authors Haven')
 
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view()),
     path('users/', RegistrationAPIView.as_view(), name="registration"),
     path('users/login/', LoginAPIView.as_view(), name = "user_login"),
-    path('swagger/', schema_view),
     path('users/verified_account/<token>/<uid>', AccountVerified.as_view(), name="verify_account"),
     path('users/password_reset/', PasswordResetAPIView.as_view()),
     path('users/password_update/<token>', PasswordUpdateAPIView.as_view()),

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -47,7 +47,9 @@ INSTALLED_APPS = [
     'authors.apps.profiles',
     'authors.apps.articles',
     'rest_framework_swagger',
+    'drf_yasg',
     'authors.apps.comments',
+   
 ]
 
 MIDDLEWARE = [

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -15,6 +15,19 @@ Including another URLconf
 """
 from django.urls import include, path
 from django.contrib import admin
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Authors Haven",
+      default_version='v1',
+    #   description="Test description",
+    #   terms_of_service="https://www.google.com/policies/terms/",
+    #   contact=openapi.Contact(email="contact@snippets.local"),
+    #   license=openapi.License(name="BSD License"),
+   ),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -23,4 +36,5 @@ urlpatterns = [
     path('api/', include('authors.apps.profiles.urls')),
     path('api/social/', include('authors.apps.social_auth_login.urls')),
     path('api/', include('authors.apps.comments.urls')),
+    path('api/swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,10 @@ django-cors-middleware==1.3.1
 django-extensions==2.1.2
 django-heroku==0.3.1
 django-rest-swagger==2.2.0
+django-social-share==1.3.0
 djangorestframework==3.8.2
 docopt==0.6.2
+drf-yasg==1.11.1
 facebook-sdk==3.1.0
 future==0.17.1
 google-api-python-client==1.7.6
@@ -25,6 +27,7 @@ google-auth-oauthlib==0.2.0
 gunicorn==19.9.0
 httplib2==0.12.0
 idna==2.7
+inflection==0.3.1
 isort==4.3.4
 itypes==1.1.0
 Jinja2==2.10
@@ -42,9 +45,11 @@ PyJWT==1.4.2
 pylint==2.2.1
 python-twitter==3.5
 pytz==2018.7
+PyYAML==3.13
 requests==2.20.1
 requests-oauthlib==1.0.0
 rsa==4.0
+ruamel.yaml==0.15.80
 simplejson==3.16.0
 six==1.11.0
 uritemplate==3.0.0


### PR DESCRIPTION
### What does this PR do?
Add functionality for authenticated users to be able to share articles across social media and using email. 
#### Description of the task to be completed
- Create classes in the article view for social media sharing and using emails for sharing.
- Write tests for the social share views.
#### How should this be manually tested?
- Get all articles.
- Get the article slug.
- To share via email: POST / api/articles/\<slug\>/email/
- To share via twitter: POST api/articles/\<slug\>/twitter/
- To share via facebook: POST api/articles/\<slug\>/facebook/
#### What are the relevant pivotal tracker stories?
[#162163182](https://www.pivotaltracker.com/story/show/162163182)