### PR TITLE
#162163187 users should be able to like a specific comment

### DIFF
--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils import timezone
 from authors.apps.articles.models import Article
 from authors.apps.authentication.models import User
-
+from authors.apps.core.models import TimestampedModel
 
 class Comments(models.Model):
     """
@@ -22,6 +22,10 @@ class Comments(models.Model):
 
     created_at = models.DateTimeField(
         auto_created=True, auto_now=False, default=timezone.now)
+    likes = models.IntegerField(
+        db_index=True,
+        default=False
+    )
 
     def __str__(self):
         """
@@ -68,3 +72,24 @@ class Replies(models.Model):
     class Meta:
 
         ordering = ['created_at']
+
+
+class Impressions(TimestampedModel):
+    """
+    Create an `Impression` with a slug, user details, likes and dislikes.
+    """
+
+    comment = models.ForeignKey(
+        Comments,
+        on_delete=models.CASCADE,
+        default=None
+    )
+    user = models.ForeignKey(
+        'profiles.UserProfile',
+        on_delete=models.CASCADE,
+        default=None
+    )
+    likes = models.BooleanField(
+        db_index=True,
+        default=None
+    )

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from authors.apps.articles.models import Article
-from authors.apps.comments.models import Comments, Replies
+from authors.apps.comments.models import Comments, Replies, Impressions
 from authors.apps.authentication.models import User
 from authors.apps.profiles.models import UserProfile
 from authors.apps.profiles.serializers import GetUserProfileSerializer
@@ -48,4 +48,32 @@ class CommentSerializer(serializers.ModelSerializer):
             'article',
             'author',
             'created_at',
-            'replies')
+            'replies',
+            'likes'
+            )
+
+class ImpressionSerializer(serializers.ModelSerializer):
+    """
+    Serializes impressions requests and adds to an Article.
+    """
+
+    createdAt = serializers.SerializerMethodField(method_name='get_created_at')
+    updatedAt = serializers.SerializerMethodField(method_name='get_updated_at')
+
+    class Meta:
+        model = Impressions
+        fields = (
+            'comment',
+            'user',
+            'likes',
+            'updatedAt',
+            'createdAt',
+        )
+
+    def get_created_at(self, instance):
+
+        return instance.created_at.isoformat()
+
+    def get_updated_at(self, instance):
+
+        return instance.updated_at.isoformat()

--- a/authors/apps/comments/tests/test_like_comments.py
+++ b/authors/apps/comments/tests/test_like_comments.py
@@ -1,0 +1,60 @@
+from rest_framework.test import APIClient, APITestCase, APIRequestFactory
+from rest_framework import status
+from .test_comment_data import CommentTest
+
+
+class Test_Impression(CommentTest):
+
+    def test_add_like_impression(self, response=[]):
+        article = self.client.post(
+            '/api/articles/',
+            data=self.new_article,
+            format='json')
+        slug = self.get_slug(article)
+        
+        self.client.post(
+            '/api/{}/comments/'.format(slug),
+            data=self.post_comment,
+            format='json')
+
+        response = self.client.get(
+            '/api/{}/comments/'.format(slug),
+            format='json')
+
+        for i in response.data['comments']:
+            self.id = i['id']
+        id = self.id
+        response1 = self.client.post('/api/comment/like/{}'.format(id), format='json')
+
+        self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
+
+    def test_add_like_impression_twice(self, response=[]):
+        article = self.client.post(
+            '/api/articles/',
+            data=self.new_article,
+            format='json')
+        slug = self.get_slug(article)
+        
+        self.client.post(
+            '/api/{}/comments/'.format(slug),
+            data=self.post_comment,
+            format='json')
+
+        response = self.client.get(
+            '/api/{}/comments/'.format(slug),
+            format='json')
+
+        for i in response.data['comments']:
+            self.id = i['id']
+        id = self.id
+        self.client.post('/api/comment/like/{}'.format(id), format='json')
+        response1 = self.client.post('/api/comment/like/{}'.format(id), format='json')
+
+        self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
+    
+    def test_add_like_impression_doesnot_exist(self):
+        id = 908766
+        response1 = self.client.post('/api/comment/like/{}'.format(id), format='json')
+
+        self.assertEqual(response1.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Invalid pk \"908766\" - object does not exist.', str(response1.data))

--- a/authors/apps/comments/urls.py
+++ b/authors/apps/comments/urls.py
@@ -3,7 +3,7 @@ Defines urls used in comments package
 """
 from django.urls import path
 from rest_framework.routers import DefaultRouter
-from authors.apps.comments.views import CommentsView, RepliesView
+from authors.apps.comments.views import CommentsView, RepliesView, LikeComment
 
 urlpatterns = [
 
@@ -11,6 +11,7 @@ urlpatterns = [
     path('comment/<Id>/', CommentsView.as_view()),
     path('comment/<commentID>/replies/', RepliesView.as_view()),
     path('comment/replies/<Id>/', RepliesView.as_view()),
+    path('comment/like/<comment_id>', LikeComment.as_view()),
 
 ]
 


### PR DESCRIPTION
**What does this PR do?**
This Pull Request adds the following functionality to the comments app:
	•	Users can like specific comments of an article

**Description of Task to be completed?**
Currently, users can only comment on an article. This task adds the ability for any registered user to like any comment available.

**How should this be manually tested?**
	•	Make migrations: `./manage.py make migrations`
	•	Migrate: `./manage.py migrate`
	•	Run the server: `./manage.py runserver`
	•	Open postman and test these endpoints:

**Like a comment** 
POST `http://127.0.0.1:8000/api/comment/like/<comment_id>`

**What are the relevant pivotal tracker stories?**
[#162163187](https://www.pivotaltracker.com/story/show/162163187)

**Any background context you want to add?**
You don’t need a body when using these endpoint so add the comment id to add the like to a particular comment so once the user sends a post to the like endpoint the functionality will be triggered.

**Screenshots (if appropriate)**
when the like endpoint is accessed:
<img width="798" alt="screen shot 2018-12-19 at 9 12 46 pm" src="https://user-images.githubusercontent.com/9946845/50239330-f3371680-03d2-11e9-806b-f3cb97b78c6c.png">

when the comment is fetched showing the count:
<img width="800" alt="screen shot 2018-12-19 at 9 13 04 pm" src="https://user-images.githubusercontent.com/9946845/50239346-fdf1ab80-03d2-11e9-9384-d99aef575a93.png">
