### PR TITLE
#162163182 Fix bug for authenticated users to be able to share articles

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -447,7 +447,7 @@ class EmailShareView(APIView):
             
             Article.objects.get(slug=slug)
 
-            current_site = 'http://{}'.format(get_current_site(request))
+            current_site = 'https://{}'.format(get_current_site(request))
             route = 'api/articles'
             url = "{}/{}/{}".format(current_site, route, slug)
 
@@ -455,7 +455,7 @@ class EmailShareView(APIView):
                 "EMAIL_HOST_USER", "seven.zeusgeek@gmail.com")
             recipient = request.user.email
             subject = "Authors Haven"
-            body = "Click here to enjoy the article {}/".format(url)
+            body = "Click here to enjoy the article {}".format(url)
             send_mail(subject, body, from_email, [recipient], fail_silently=False)
 
             return Response(


### PR DESCRIPTION
### What does this PR do?
Fix a bug for users to share articles via email. 
#### Description of the task to be completed
- Remove trailing backslash in the link for sharing an article.
#### How should this be manually tested?
- Get all articles.
- Get the article slug.
- To share via email: POST / api/articles/\<slug\>/email/
#### What are the relevant pivotal tracker stories?
[#162163182](https://www.pivotaltracker.com/story/show/162163182)