### PR TITLE
#163357225 Fix social login with Facebook and Google

### DIFF
--- a/authors/apps/social_auth_login/register.py
+++ b/authors/apps/social_auth_login/register.py
@@ -6,45 +6,57 @@ from authors.apps.authentication.renderers import UserJSONRenderer
 
 
 def register_facebook_user(user_id, email, name):
-    user = User.objects.filter(facebook_id=user_id)
-    if not user.exists():
+    filtered_facebook_id = User.objects.filter(facebook_id=user_id)
+    filtered_email = User.objects.filter(email=email)
+
+    if filtered_facebook_id:
+       registered_user = authenticate(email=email, password="XXXXXXXX")
+       return registered_user.token
+
+    elif not filtered_facebook_id and not filtered_email:
         user = {
-            'username': name, 'email': email, 'password': 'XXXXXXXX'}
+           'username': name, 'email': email, 'password': 'XXXXXXXX'}
         User.objects.create_user(**user)
         User.objects.filter(email=email).update(facebook_id=user_id)
         new_user = authenticate(email=email, password="XXXXXXXX")
         return new_user.token
     else:
-        User.objects.filter(facebook_id=user_id)
-        registered_user = authenticate(email=email, password="XXXXXXXX")
-        return registered_user.token
+        return ("A user with this email already exists, Please login")
 
 
 def register_google_user(user_id, email, name):
-    user = User.objects.filter(google_id=user_id)
-    if not user.exists():
-        user = {
-            'username': name, 'email': email, 'password': 'XXXXXXXX'}
+    filtered_google_id=User.objects.filter(google_id=user_id)
+    filtered_email=User.objects.filter(email=email)
+
+    if filtered_google_id:
+       registered_user=authenticate(email=email, password="XXXXXXXX")
+       return registered_user.token
+
+    elif not filtered_google_id and not filtered_email:
+        user={
+           'username': name, 'email': email, 'password': 'XXXXXXXX'}
         User.objects.create_user(**user)
         User.objects.filter(email=email).update(google_id=user_id)
-        new_user = authenticate(email=email, password="XXXXXXXX")
+        new_user=authenticate(email=email, password="XXXXXXXX")
         return new_user.token
     else:
-        User.objects.filter(google_id=user_id)
-        registered_user = authenticate(email=email, password="XXXXXXXX")
-        return registered_user.token
+        return ("A user with this email already exists, Please login")
 
 
 def register_twitter_user(user_id, email, name):
-    user = User.objects.filter(twitter_id=user_id)
-    if not user.exists():
-        user = {
-            'username': name, 'email': email, 'password': 'XXXXXXXX'}
+    filtered_twitter_id=User.objects.filter(twitter_id=user_id)
+    filtered_email=User.objects.filter(email=email)
+
+    if filtered_facebook_id:
+       registered_user=authenticate(email=email, password="XXXXXXXX")
+       return registered_user.token
+
+    elif not filtered_twitter_id and not filtered_email:
+        user={
+           'username': name, 'email': email, 'password': 'XXXXXXXX'}
         User.objects.create_user(**user)
         User.objects.filter(email=email).update(twitter_id=user_id)
-        new_user = authenticate(email=email, password="XXXXXXXX")
+        new_user=authenticate(email=email, password="XXXXXXXX")
         return new_user.token
     else:
-        User.objects.filter(twitter_id=user_id)
-        registered_user = authenticate(email=email, password="XXXXXXXX")
-        return registered_user.token
+        return ("A user with this email already exists, Please login")


### PR DESCRIPTION
## What does this PR do?
- The PR ensures that the ```Internal server error 500``` error when social users login with previously registered emails is fixed.
### Description of task to be completed?
- Social users logging in with previously registered emails would receive an internal error 500 when logging in. Since the application does not allow duplicate emails and the exception wasn't handled earlier, the error persisted.
- To handle the bug, an exception has been created in that when a user logs in with an already registered email, an error message is returned and the application doesn't crash.
### How should this be manually tested?
- Clone the repository.
- Install the requirements ```pip install -r requirements.txt```
- Access the social login routes using Postman.
<img width="1110" alt="screen shot 2019-01-21 at 12 34 28" src="https://user-images.githubusercontent.com/31479458/51465523-1d387b80-1d79-11e9-99a5-f372de7fbe91.png">
<img width="1114" alt="screen shot 2019-01-21 at 12 35 07" src="https://user-images.githubusercontent.com/31479458/51465525-1f023f00-1d79-11e9-80ca-fd652b5d12dc.png">

### What are the relevant pivotal tracker stories?
[#163357225](https://www.pivotaltracker.com/story/show/163357225)